### PR TITLE
fix plotting the wrong t-statistic line

### DIFF
--- a/step_detect.py
+++ b/step_detect.py
@@ -42,7 +42,8 @@ def t_scan(L, window = 1e3):
     pool    = mp.Pool(processes = mp.cpu_count() - 1)
     results = [pool.apply_async(_t_scan_drone, args=(L, n_cols, frame, window)) for frame in frames]
     results = [r.get() for r in results]
-    
+    pool.close()
+
     for index, row in results:
         t_stat[index] = row
     


### PR DESCRIPTION
Fixes a bug where the t-statistic plot in the iPython demo was plotting the same line twice
